### PR TITLE
ap - add loadsubjects placeholder page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
+import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -18,7 +19,12 @@ function App() {
         <Route exact path="/" element={<HomePage />} />
         <Route exact path="/profile" element={<ProfilePage />} />
         {
-          hasRole(currentUser, "ROLE_ADMIN") && <Route exact path="/admin/users" element={<AdminUsersPage />} />
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/admin/users" element={<AdminUsersPage />} />
+              <Route exact path="/admin/loadsubjects" element={<AdminLoadSubjectsPage />} />
+            </>
+          )
         }
       </Routes>
     </BrowserRouter>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -46,6 +46,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_ADMIN") && (
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/loadsubjects" data-testid="appnavbar-admin-loadsubjects">Load Subjects</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/pages/AdminLoadSubjectsPage.js
+++ b/frontend/src/main/pages/AdminLoadSubjectsPage.js
@@ -1,12 +1,12 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-export default function LoadSubjectsPage() {
+export default function AdminLoadSubjectsPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Todos</h1>
+        <h1>Load Subjects</h1>
         <p>
-          This is where the index page will go
+          This is where the Load Subjects page will go
         </p>
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/LoadSubjectsPage.js
+++ b/frontend/src/main/pages/LoadSubjectsPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function LoadSubjectsPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Todos</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/stories/pages/AdminLoadSubjectsPage.stories.js
+++ b/frontend/src/stories/pages/AdminLoadSubjectsPage.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
+
+export default {
+    title: 'pages/AdminLoadSubjectsPage',
+    component: AdminLoadSubjectsPage
+};
+
+const Template = () => <AdminLoadSubjectsPage />;
+
+export const Default = Template.bind({});
+

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -41,7 +41,11 @@ describe("AppNavbar tests", () => {
 
         await waitFor(() => expect(getByText("Welcome, phtcon@ucsb.edu")).toBeInTheDocument());
         const adminMenu = getByTestId("appnavbar-admin-dropdown");
-        expect(adminMenu).toBeInTheDocument();        
+        expect(adminMenu).toBeInTheDocument();  
+        const aElement = adminMenu.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-admin-loadsubjects")).toBeInTheDocument() );      
     });
 
     test("renders H2Console and Swagger links correctly", async () => {

--- a/frontend/src/tests/pages/AdminLoadSubjectsPage.test.js
+++ b/frontend/src/tests/pages/AdminLoadSubjectsPage.test.js
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("AdminLoadSubjectsPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing for admin user", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminLoadSubjectsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+
+});


### PR DESCRIPTION
# Overview

In this pull request I added the loadsubjects placeholder page under the admin dropdown. I added an entry to the storybook and wrote tests for the new page. 

# Details
![storybook](https://user-images.githubusercontent.com/56096744/156449374-26d4bb3c-0773-46b5-a011-c7bbd707ef28.jpg)
![local](https://user-images.githubusercontent.com/56096744/156449381-440da5fa-55e0-4fea-83fd-e229bab9e9cd.jpg)
![coverage](https://user-images.githubusercontent.com/56096744/156449385-f1953bd7-12d8-495f-84ff-517e70b95e1f.jpg)

