### PR TITLE
W22 5pm 2 zw,ap - add put and delete endpoints for personalschedules

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -97,5 +97,69 @@ public class PersonalSchedulesController extends ApiController {
         return savedPersonalSchedule;
     }
 
+    @ApiOperation(value = "Delete a personal schedule owned by this user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @DeleteMapping("")
+    public Object deleteSchedule(
+            @ApiParam("id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser();
+        PersonalSchedule personalschedule = personalscheduleRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
+          personalscheduleRepository.delete(personalschedule);
+
+        return genericMessage("Personal schedule with id %s deleted".formatted(id));
+
+    }
+
+    @ApiOperation(value = "Delete another user's personal schedule")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/admin")
+    public Object deleteSchedule_Admin(
+            @ApiParam("id") @RequestParam Long id) {
+              PersonalSchedule personalschedule = personalscheduleRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+          personalscheduleRepository.delete(personalschedule);
+
+        return genericMessage("Personal schedule with id %s deleted".formatted(id));
+    }
+
+    @ApiOperation(value = "Update a single personal schedule (if it belongs to current user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PutMapping("")
+    public PersonalSchedule putScheduleById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid PersonalSchedule incomingSchedule) {
+        User currentUser = getCurrentUser().getUser();
+        PersonalSchedule personalschedule = personalscheduleRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        personalschedule.setName(incomingSchedule.getName());
+        personalschedule.setDescription(incomingSchedule.getDescription());
+        personalschedule.setQuarter(incomingSchedule.getQuarter());
+
+        personalscheduleRepository.save(personalschedule);
+
+        return personalschedule;
+    }
+
+    @ApiOperation(value = "Update a single Schedule (regardless of ownership, admin only, can't change ownership)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/admin")
+    public PersonalSchedule putScheduleById_admin(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid PersonalSchedule incomingSchedule) {
+              PersonalSchedule personalschedule = personalscheduleRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        personalschedule.setName(incomingSchedule.getName());
+        personalschedule.setDescription(incomingSchedule.getDescription());
+        personalschedule.setQuarter(incomingSchedule.getQuarter());
+
+        personalscheduleRepository.save(personalschedule);
+
+        return personalschedule;
+    }
+    
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesController.java
@@ -108,7 +108,7 @@ public class PersonalSchedulesController extends ApiController {
 
           personalscheduleRepository.delete(personalschedule);
 
-        return genericMessage("Personal schedule with id %s deleted".formatted(id));
+        return genericMessage("PersonalSchedule with id %s deleted".formatted(id));
 
     }
 
@@ -122,7 +122,7 @@ public class PersonalSchedulesController extends ApiController {
 
           personalscheduleRepository.delete(personalschedule);
 
-        return genericMessage("Personal schedule with id %s deleted".formatted(id));
+        return genericMessage("PersonalSchedule with id %s deleted".formatted(id));
     }
 
     @ApiOperation(value = "Update a single personal schedule (if it belongs to current user)")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -331,7 +331,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // assert
         verify(personalscheduleRepository, times(1)).findByIdAndUser(15L, u);
         Map<String, Object> json = responseToJson(response);
-        assertEquals("Personal schedule with id 15 not found", json.get("message"));
+        assertEquals("PersonalSchedule with id 15 not found", json.get("message"));
     }
 
     @WithMockUser(roles = { "USER" })
@@ -352,7 +352,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // assert
         verify(personalscheduleRepository, times(1)).findByIdAndUser(31L, u);
         Map<String, Object> json = responseToJson(response);
-        assertEquals("Personal schedule with id 31 not found", json.get("message"));
+        assertEquals("PersonalSchedule with id 31 not found", json.get("message"));
     }
 
 
@@ -553,7 +553,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         verify(personalscheduleRepository, times(1)).findById(77L);
         Map<String, Object> json = responseToJson(response);
         assertEquals("EntityNotFoundException", json.get("type"));
-        assertEquals("PersonalSchedule  with id 77 not found", json.get("message"));
+        assertEquals("PersonalSchedule with id 77 not found", json.get("message"));
     }
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -309,7 +309,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         verify(personalscheduleRepository, times(1)).findByIdAndUser(15L, u);
         verify(personalscheduleRepository, times(1)).delete(ps1);
         Map<String, Object> json = responseToJson(response);
-        assertEquals("Personal schedule with id 15 deleted", json.get("message"));
+        assertEquals("PersonalSchedule with id 15 deleted", json.get("message"));
     }
 
     @WithMockUser(roles = { "USER" })
@@ -375,7 +375,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         verify(personalscheduleRepository, times(1)).findById(16L);
         verify(personalscheduleRepository, times(1)).delete(ps1);
         Map<String, Object> output = responseToJson(response);
-        assertEquals("Personal schedule with id 16 deleted", output.get("message"));
+        assertEquals("PersonalSchedule with id 16 deleted", output.get("message"));
     }
 
     @WithMockUser(roles = { "ADMIN", "USER" })
@@ -409,7 +409,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // This should get ignored and overwritten with current user when todo is saved
 
         PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(otherUser).id(67L).build();
-        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").id(67L).build();
+        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(u).id(67L).build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
         String expectedReturn = mapper.writeValueAsString(correctSchedule);
@@ -501,9 +501,9 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         User yetAnotherUser = User.builder().id(512L).build();
         // We deliberately put the wrong user on the updated schedule
         // We expect the controller to ignore this and keep the user the same
-        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(yetAnotherUser).id(77L)
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(yetAnotherUser).id(77L)
                 .build();
-        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(77L)
+        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(otherUser).id(77L)
                 .build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -296,7 +296,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
 
         User u = currentUserService.getCurrentUser().getUser();
-        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(u).id(15L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(u).id(15L).build();
         when(personalscheduleRepository.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(ps1));
 
         // act
@@ -319,7 +319,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(98L).build();
-        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(u).id(15L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(u).id(15L).build();
         when(personalscheduleRepository.findByIdAndUser(eq(15L), eq(otherUser))).thenReturn(Optional.of(ps1));
 
         // act
@@ -340,7 +340,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(98L).build();
-        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(31L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(otherUser).id(31L).build();
         when(personalscheduleRepository.findById(eq(31L))).thenReturn(Optional.of(ps1));
 
         // act
@@ -362,7 +362,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
 
         User otherUser = User.builder().id(98L).build();
-        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(16L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(otherUser).id(16L).build();
         when(personalscheduleRepository.findById(eq(16L))).thenReturn(Optional.of(ps1));
 
         // act
@@ -404,12 +404,12 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(999).build();
-        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(u).id(67L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(u).id(67L).build();
         // We deliberately set the user information to another user
         // This should get ignored and overwritten with current user when todo is saved
 
-        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(otherUser).id(67L).build();
-        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(u).id(67L).build();
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("20222").user(otherUser).id(67L).build();
+        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("20222").user(u).id(67L).build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
         String expectedReturn = mapper.writeValueAsString(correctSchedule);
@@ -438,7 +438,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
 
         User u = currentUserService.getCurrentUser().getUser();
-        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").id(67L).build();
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("20222").id(67L).build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
 
@@ -467,8 +467,8 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
         User u = currentUserService.getCurrentUser().getUser();
         User otherUser = User.builder().id(98L).build();
-        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(31L).build();
-        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").id(31L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(otherUser).id(31L).build();
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("20222").id(31L).build();
 
         when(personalscheduleRepository.findByIdAndUser(eq(31L), eq(otherUser))).thenReturn(Optional.of(ps1));
 
@@ -497,13 +497,13 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
 
         User otherUser = User.builder().id(255L).build();
-        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(77L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(otherUser).id(77L).build();
         User yetAnotherUser = User.builder().id(512L).build();
         // We deliberately put the wrong user on the updated schedule
         // We expect the controller to ignore this and keep the user the same
-        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(yetAnotherUser).id(77L)
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("20222").user(yetAnotherUser).id(77L)
                 .build();
-        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(otherUser).id(77L)
+        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("20222").user(otherUser).id(77L)
                 .build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);
@@ -533,7 +533,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         // arrange
 
         User otherUser = User.builder().id(345L).build();
-        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(77L)
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("20221").user(otherUser).id(77L)
                 .build();
 
         String requestBody = mapper.writeValueAsString(updatedSchedule);

--- a/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/PersonalSchedulesControllerTests.java
@@ -290,4 +290,270 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
     }
 
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_schedules__user_logged_in__delete_schedule() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(u).id(15L).build();
+        when(personalscheduleRepository.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(ps1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/personalschedules?id=15")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(15L, u);
+        verify(personalscheduleRepository, times(1)).delete(ps1);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Personal schedule with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_schedules__user_logged_in__delete_schedule_that_does_not_exist() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        User otherUser = User.builder().id(98L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(u).id(15L).build();
+        when(personalscheduleRepository.findByIdAndUser(eq(15L), eq(otherUser))).thenReturn(Optional.of(ps1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/personalschedules?id=15")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(15L, u);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Personal schedule with id 15 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_schedules__user_logged_in__cannot_delete_delete_belonging_to_another_user() throws Exception {
+        // arrange
+        User u = currentUserService.getCurrentUser().getUser();
+        User otherUser = User.builder().id(98L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(31L).build();
+        when(personalscheduleRepository.findById(eq(31L))).thenReturn(Optional.of(ps1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/personalschedules?id=31")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(31L, u);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Personal schedule with id 31 not found", json.get("message"));
+    }
+
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void api_schedules__admin_logged_in__delete_schedule() throws Exception {
+        // arrange
+
+        User otherUser = User.builder().id(98L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(16L).build();
+        when(personalscheduleRepository.findById(eq(16L))).thenReturn(Optional.of(ps1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/personalschedules/admin?id=16")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findById(16L);
+        verify(personalscheduleRepository, times(1)).delete(ps1);
+        Map<String, Object> output = responseToJson(response);
+        assertEquals("Personal schedule with id 16 deleted", output.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void api_schedules__admin_logged_in__cannot_delete_schedule_that_does_not_exist() throws Exception {
+        // arrange
+
+        when(personalscheduleRepository.findById(eq(17L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/personalschedules/admin?id=17")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findById(17L);
+        Map<String, Object> output = responseToJson(response);
+        assertEquals("PersonalSchedule with id 17 not found", output.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_schedules__user_logged_in__put_schedule() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        User otherUser = User.builder().id(999).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(u).id(67L).build();
+        // We deliberately set the user information to another user
+        // This should get ignored and overwritten with current user when todo is saved
+
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").user(otherUser).id(67L).build();
+        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").id(67L).build();
+
+        String requestBody = mapper.writeValueAsString(updatedSchedule);
+        String expectedReturn = mapper.writeValueAsString(correctSchedule);
+
+        when(personalscheduleRepository.findByIdAndUser(eq(67L), eq(u))).thenReturn(Optional.of(ps1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/personalschedules?id=67")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(67L, u);
+        verify(personalscheduleRepository, times(1)).save(correctSchedule); // should be saved with correct user
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_schedules__user_logged_in__cannot_put_schedule_that_does_not_exist() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").id(67L).build();
+
+        String requestBody = mapper.writeValueAsString(updatedSchedule);
+
+        when(personalscheduleRepository.findByIdAndUser(eq(67L), eq(u))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/personalschedules?id=67")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(67L, u);
+        Map<String, Object> output = responseToJson(response);
+        assertEquals("PersonalSchedule with id 67 not found", output.get("message"));
+    }
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_schedules__user_logged_in__cannot_put_schedule_for_another_user() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        User otherUser = User.builder().id(98L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(31L).build();
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 2").description("Description 2").quarter("Quarter 2").id(31L).build();
+
+        when(personalscheduleRepository.findByIdAndUser(eq(31L), eq(otherUser))).thenReturn(Optional.of(ps1));
+
+        String requestBody = mapper.writeValueAsString(updatedSchedule);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/personalschedules?id=31")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(31L, u);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("PersonalSchedule with id 31 not found", json.get("message"));
+    }
+
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void api_schedules__admin_logged_in__put_schedule() throws Exception {
+        // arrange
+
+        User otherUser = User.builder().id(255L).build();
+        PersonalSchedule ps1 = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(77L).build();
+        User yetAnotherUser = User.builder().id(512L).build();
+        // We deliberately put the wrong user on the updated schedule
+        // We expect the controller to ignore this and keep the user the same
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(yetAnotherUser).id(77L)
+                .build();
+        PersonalSchedule correctSchedule = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(77L)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(updatedSchedule);
+        String expectedJson = mapper.writeValueAsString(correctSchedule);
+
+        when(personalscheduleRepository.findById(eq(77L))).thenReturn(Optional.of(ps1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/personalschedules/admin?id=77")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findById(77L);
+        verify(personalscheduleRepository, times(1)).save(correctSchedule);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void api_schedules__admin_logged_in__cannot_put_schedule_that_does_not_exist() throws Exception {
+        // arrange
+
+        User otherUser = User.builder().id(345L).build();
+        PersonalSchedule updatedSchedule = PersonalSchedule.builder().name("Name 1").description("Description 1").quarter("Quarter 1").user(otherUser).id(77L)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(updatedSchedule);
+
+        when(personalscheduleRepository.findById(eq(77L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/personalschedules/admin?id=77")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(personalscheduleRepository, times(1)).findById(77L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("PersonalSchedule  with id 77 not found", json.get("message"));
+    }
+
 }


### PR DESCRIPTION
# Overview

In this PR we added the put(edit) and delete api endpoints for personalschedules in addition to tests. The endpoints work as expected and are well documented on swagger-ui

# Issues Addressed

#37 
#38 

# Details

Documentation on localhost
![local](https://user-images.githubusercontent.com/56096744/157751510-b799494d-c0e6-4cee-9f37-abe910a24023.jpg)

Documentation on heroku-qa
![heroku](https://user-images.githubusercontent.com/56096744/157751522-6d5add27-f73a-46c5-b0b9-2c071436b2b5.jpg)

Test Coverage
![cov](https://user-images.githubusercontent.com/56096744/157751527-24116d87-c394-4e11-9653-49990696dc49.jpg)

Mutation Testing
![mutation](https://user-images.githubusercontent.com/56096744/157751534-7d34b719-01da-4f89-b80c-a1494a89834f.jpg)

