### PR TITLE
W22 5pm 2 al - Allow Subjects te be passed to BasicCourseForm

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
 import { toast } from "react-toastify";
 
-import { allTheSubjects } from "fixtures/subjectFixtures";
+import { oneSubject } from "fixtures/subjectFixtures";
 import { allTheLevels } from "fixtures/levelsFixtures";
 import { quarterRange } from "main/utils/quarterUtilities";
 
@@ -10,7 +10,7 @@ import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
 import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
 
-const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
+const BasicCourseSearchForm = ({ subjects, setCourseJSON, fetchJSON }) => {
   const quarters = quarterRange("20084", "20222");
 
   // Stryker disable all : not sure how to test/mock local storage
@@ -18,12 +18,16 @@ const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
   const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
 
-  const firstDepartment = allTheSubjects[0].subjectCode;
+  const firstDepartment = "ANTH";
+  subjects = (subjects === undefined) ? oneSubject: subjects;
+
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || firstDepartment);
   const [level, setLevel] = useState(localLevel || "U");
   const [errorNotified, setErrorNotified] = useState(false);
   // Stryker restore all
+
+  
 
   const handleSubmit = (event) => {
     toast(
@@ -37,6 +41,7 @@ const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
       setCourseJSON(courseJSON);
     });
   };
+
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
   return (
@@ -53,7 +58,7 @@ const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
           </Col>
           <Col md="auto">
             <SingleSubjectDropdown
-              subjects={allTheSubjects}
+              subjects={subjects}
               subject={subject}
               setSubject={setSubject}
               controlId={"BasicSearch.Subject"}

--- a/frontend/src/stories/components/BasicCourseSearch/BasicCourseSearchForm.stories.js
+++ b/frontend/src/stories/components/BasicCourseSearch/BasicCourseSearchForm.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm"
+import { threeSubjects, allTheSubjects } from 'fixtures/subjectFixtures';
 
 export default {
     title: 'components/BasicCourseSearch/BasicCourseSearchForm',
@@ -17,6 +18,24 @@ const Template = (args) => {
 export const Default = Template.bind({});
 
 Default.args = {
+    submitText: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};
+
+
+export const ThreeSubjectsLoaded = Template.bind({});
+
+ThreeSubjectsLoaded.args = {
+    subjects : threeSubjects,
+    submitText: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};
+
+
+export const AllSubjectsLoaded = Template.bind({});
+
+AllSubjectsLoaded.args = {
+    subjects : allTheSubjects,
     submitText: "Create",
     submitAction: () => { console.log("Submit was clicked"); }
 };

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -3,6 +3,7 @@ import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "react-toastify";
 
+import { allTheSubjects } from "fixtures/subjectFixtures";
 import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
 
 jest.mock("react-toastify", () => ({
@@ -29,7 +30,7 @@ describe("BasicCourseSearchForm tests", () => {
 	});
 
 	test("when I select a subject, the state for subject changes", () => {
-		const { getByLabelText } = render(<BasicCourseSearchForm />);
+		const { getByLabelText } = render(<BasicCourseSearchForm subjects={allTheSubjects} />);
 		const selectSubject = getByLabelText("Subject Area");
 		userEvent.selectOptions(selectSubject, "MATH");
 		expect(selectSubject.value).toBe("MATH");
@@ -54,6 +55,7 @@ describe("BasicCourseSearchForm tests", () => {
 
 		const { getByText, getByLabelText } = render(
 			<BasicCourseSearchForm
+				subjects={allTheSubjects}
 				setCourseJSON={setCourseJSONSpy}
 				fetchJSON={fetchJSONSpy}
 			/>
@@ -99,6 +101,7 @@ describe("BasicCourseSearchForm tests", () => {
 
 		const { getByText, getByLabelText } = render(
 			<BasicCourseSearchForm
+				subjects={allTheSubjects}
 				setCourseJSON={setCourseJSONSpy}
 				fetchJSON={fetchJSONSpy}
 			/>


### PR DESCRIPTION
# Overview

Instead of hardcoded subject fixtures, allow variable number of subjects to be passed by backend into BasicCourseForm.js

# Storybook Screenshots
## Nothing Passed In, Default
![image](https://user-images.githubusercontent.com/49248229/157997915-1dd8f8e6-05d6-4738-9d49-f5b8f04885de.png)
## Three Subjects Passed In
![image](https://user-images.githubusercontent.com/49248229/157997956-a86cfb61-41c4-4858-b249-6168495e4120.png)
 

